### PR TITLE
fix: Run init in container to forward signals to Node.js

### DIFF
--- a/docker-compose.yml.tpl
+++ b/docker-compose.yml.tpl
@@ -2,6 +2,7 @@ version: '3'
 services:
     app:
         image: docker.pkg.github.com/strangedev/neuron-buildbot/neuron-buildbot:latest
+        init: true
         ports: 
             - {{ buildbot.port }}:{{ buildbot.port }}
         volumes: 

--- a/docker-compose.yml.tpl
+++ b/docker-compose.yml.tpl
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 services:
     app:
         image: docker.pkg.github.com/strangedev/neuron-buildbot/neuron-buildbot:latest


### PR DESCRIPTION
This is necessary because node applications otherwise cannot correctly handle signals. This is the reason that `docker-compose down` takes forever to stop the `app` container - the app never gets the notice that it's supposed to shut down and is killed after a timeout.